### PR TITLE
Dynamic-reconfigure pkg dependency brakes dependencies

### DIFF
--- a/rotors_control/package.xml
+++ b/rotors_control/package.xml
@@ -8,7 +8,6 @@
   <license>TODO: License declaration</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <depend>dynamic_reconfigure</depend>
   <depend>mav_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>


### PR DESCRIPTION
The 'dynamic_reconfigure' pkg does not exist in ROS2.
Building this package with that dependency is not possible.